### PR TITLE
 left align file columns

### DIFF
--- a/lib/assets/base.css
+++ b/lib/assets/base.css
@@ -131,7 +131,7 @@ div.coverage-summary th.pct { border-right: none !important; }
 div.coverage-summary th.abs { border-left: none !important; text-align: right; }
 div.coverage-summary td.pct { text-align: right; border-left: 1px solid #666; }
 div.coverage-summary td.abs { text-align: right; font-size: 90%; color: #444; border-right: 1px solid #666; }
-div.coverage-summary td.file { text-align: right; border-left: 1px solid #666; white-space: nowrap;  }
+div.coverage-summary td.file { border-left: 1px solid #666; white-space: nowrap;  }
 div.coverage-summary td.pic { min-width: 120px !important;  }
 div.coverage-summary a:link { text-decoration: none; color: #000; }
 div.coverage-summary a:visited { text-decoration: none; color: #333; }


### PR DESCRIPTION
Its very difficult to parse sorted files when right aligned. Left align the file column instead. See below

before:
![istanbul-before](https://cloud.githubusercontent.com/assets/285916/7078993/08bdf500-deed-11e4-97d0-eb98145e5f51.png)

after:
![istanbul-after](https://cloud.githubusercontent.com/assets/285916/7078994/0a3157c4-deed-11e4-896d-90f3d4ed4fa1.png)
